### PR TITLE
Add sam flags to filter non-primary hits and supplementary hits

### DIFF
--- a/bin/dirseq
+++ b/bin/dirseq
@@ -193,8 +193,8 @@ if options[:ignore_directions]
 
 else
   # fwd read 1
-  read1_flag = '-F128' #account for read1 in pair, as well as single reads mapping
-  read2_flag = '-f128'
+  read1_flag = '-F0x100 -F0x800 -F128' #account for read1 in pair, as well as single reads mapping
+  read2_flag = '-F0x100 -F0x800 -f128'
   bedtools_type_flag = '-hist'
   if options[:count_type] == COUNT_COUNT_TYPE
     bedtools_type_flag = '-counts'


### PR DESCRIPTION
Hi Ben,

Sometimes more than one hits of a read will be kept, and `chimeric alignment`  also does occur during the mapping process, so I added two more flags that will filter `non-primary` and `supplementary` hits in `bam` file for downstream `bedtools` analysis. If you also think this is feasible, you can merge this branch.

Cheers,
Jie